### PR TITLE
fix: Prevent xterm.js dimension errors and improve terminal resizing

### DIFF
--- a/src/pages/LabEnvironmentPage.jsx
+++ b/src/pages/LabEnvironmentPage.jsx
@@ -33,6 +33,7 @@ const LabEnvironmentPage = () => {
   const [terminalOutputBuffer, setTerminalOutputBuffer] = useState('');
   const [isVerifyingTask, setIsVerifyingTask] = useState(false); // For loading state on verify button
   const [wsConnectionStatus, setWsConnectionStatus] = useState('Connecting...'); // 'Connecting...', 'Connected', 'Disconnected', 'Error'
+  const [activeTab, setActiveTab] = useState("instructions"); // For tracking active tab
 
 
   const connectWebSocket = useCallback(() => {
@@ -274,7 +275,7 @@ const LabEnvironmentPage = () => {
         transition={{ duration: 0.5, delay: 0.4 }}
         className="lg:w-2/3 flex flex-col"
       >
-        <Tabs defaultValue="instructions" className="w-full flex-grow flex flex-col">
+        <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full flex-grow flex flex-col">
           <TabsList className="grid w-full grid-cols-2 bg-slate-800/70 border-slate-700">
             <TabsTrigger value="instructions" className="data-[state=active]:bg-slate-700 data-[state=active]:text-sky-300">Instructions</TabsTrigger>
             <TabsTrigger value="terminal" className="data-[state=active]:bg-slate-700 data-[state=active]:text-sky-300">Terminal</TabsTrigger>
@@ -312,6 +313,7 @@ const LabEnvironmentPage = () => {
                     isConnected={wsConnectionStatus === 'Connected'} 
                     tasks={tasks} 
                     currentTaskIndex={currentTaskIndex}
+                    isTerminalVisible={activeTab === 'terminal'} // New prop
                 />
              </div>
             {activeTask && !activeTask.completed && (


### PR DESCRIPTION
This commit addresses the "Cannot read properties of undefined (reading 'dimensions')" error in xterm.js.

Changes include:

1.  **src/pages/LabEnvironmentPage.jsx:**
    *   Added state `activeTab` to track the currently selected tab in the `Tabs` component.
    *   Passed an `isTerminalVisible` prop to `TerminalEmulator`, indicating if the terminal tab is active.

2.  **src/components/lab/TerminalEmulator.jsx:**
    *   The component now accepts the `isTerminalVisible` prop.
    *   Calls to `fitAddon.fit()` (for resizing the terminal) are now conditional on `isTerminalVisible` being true. This applies to:
        *   Initial terminal setup.
        *   Re-renders of the component.
        *   The `handleWindowResize` event handler.
    *   An explicit effect was added to call `fit()` when `isTerminalVisible` becomes true (e.g., when switching to the terminal tab).
    *   The initial `fit()` calls were already deferred using `requestAnimationFrame` (from a previous commit), which is maintained.

These modifications ensure that xterm.js only attempts to calculate its dimensions and fit its container when the terminal is actually visible, preventing errors that occur when trying to measure hidden elements.