### PR TITLE
fix: Conditionally render xterm and check dimensions before fit

### DIFF
--- a/src/components/lab/TerminalEmulator.jsx
+++ b/src/components/lab/TerminalEmulator.jsx
@@ -13,161 +13,152 @@ const TerminalEmulator = ({
   isTerminalVisible, // New prop: boolean indicating if the terminal tab is active
   // tasks and currentTaskIndex are passed from parent but not directly used here anymore
 }) => {
-  const terminalRef = useRef(null);
-  const xtermRef = useRef(null);
-  const fitAddonRef = useRef(null);
+  const terminalRef = useRef(null); // Ref for the div element to host XTerm
+  const xtermRef = useRef(null); // Ref to store the XTerm.js Terminal instance
+  const fitAddonRef = useRef(null); // Ref to store the FitAddon instance
   const lastOutputLength = useRef(0); // Used to track if we should scroll to bottom
 
-  useEffect(() => {
-    if (!terminalRef.current) return;
-
-    let termInst; // To store the Xterm instance
-
-    if (!xtermRef.current) {
-      termInst = new Terminal({
-        cursorBlink: true,
-        convertEol: true,
-        theme: {
-          background: '#0F172A', // Slightly lighter than pure black, slate-900 like
-          foreground: '#E2E8F0', // Slate-200 for better readability
-          cursor: '#F87171',     // Red-400 for cursor
-          selectionBackground: '#64748B', // Slate-500
-          selectionForeground: '#FFFFFF',
-          black: '#1E293B', // Slate-800
-          red: '#F87171',   // Red-400
-          green: '#4ADE80', // Green-400
-          yellow: '#FACC15',// Yellow-400
-          blue: '#60A5FA',  // Blue-400
-          magenta: '#F472B6',// Pink-400
-          cyan: '#2DD4BF',  // Teal-400
-          white: '#F1F5F9', // Slate-100
-          brightBlack: '#64748B', // Slate-500
-          brightRed: '#FB923C',   // Orange-400
-          brightGreen: '#86EFAC',// Green-300
-          brightYellow: '#FDE047',// Yellow-300
-          brightBlue: '#93C5FD', // Blue-300
-          brightMagenta: '#F0ABFC',// Fuchsia-300
-          brightCyan: '#67E8F9',  // Cyan-300
-          brightWhite: '#FFFFFF', // White
-        },
-        fontSize: 14,
-        fontFamily: 'Menlo, "DejaVu Sans Mono", Consolas, "Lucida Console", monospace',
-        rows: 25,
-        scrollback: 1000, // Increase scrollback buffer
-      });
-
-      const currentFitAddon = new FitAddon();
-      
-      xtermRef.current = termInst;
-      fitAddonRef.current = currentFitAddon;
-
-      termInst.loadAddon(currentFitAddon);
-      termInst.open(terminalRef.current);
-      
-      if (fitAddonRef.current && isTerminalVisible) { // Ensure fitAddonRef.current is set and terminal is visible
-          requestAnimationFrame(() => {
-              try {
-                  if (fitAddonRef.current && isTerminalVisible) { // Check again inside animationFrame callback
-                       fitAddonRef.current.fit();
-                  }
-              } catch (e) {
-                  // console.warn("FitAddon fit error on initial load (rAF, visible):", e);
-              }
-          });
-      }
-      termInst.focus();
-
-      termInst.onResize(({ cols, rows }) => {
-        if (onData) {
-          onData(JSON.stringify({ type: 'resize', cols, rows }));
-        }
-      });
-      if (onData) {
-         onData(JSON.stringify({ type: 'resize', cols: termInst.cols, rows: termInst.rows }));
-      }
-
-      termInst.onData(data => {
-        if (onData && isConnected) {
-          onData(data);
-        } else if (!isConnected && termInst) { // Check termInst exists
-            termInst.writeln("\r\n[OFFLINE: Input not sent. Waiting for connection...]");
-        }
-      });
-    } else {
-        termInst = xtermRef.current;
-        if (fitAddonRef.current && isTerminalVisible) { // Check if terminal is visible
-            requestAnimationFrame(() => {
-                try {
-                    if (fitAddonRef.current && isTerminalVisible) { // Check again
-                        fitAddonRef.current.fit();
-                    }
-                } catch(e) {
-                    // console.warn("FitAddon fit error on re-render with existing term (rAF, visible):", e);
-                }
-            });
-        }
-        termInst.focus();
-    }
-    
-    if (initialOutput && initialOutput.length > lastOutputLength.current) {
-        termInst.write(initialOutput.substring(lastOutputLength.current));
-        lastOutputLength.current = initialOutput.length;
-        termInst.scrollToBottom(); // Scroll to bottom when new output is written
-    } else if (initialOutput === '' && lastOutputLength.current > 0) { 
-        // Handle buffer reset (e.g. on reconnect and clear)
-        termInst.clear(); // Clear terminal if initialOutput is reset
-        lastOutputLength.current = 0;
-    }
-
-
-    const handleWindowResize = () => {
-      if (fitAddonRef.current && isTerminalVisible) { // Check if terminal is visible
+  const handleWindowResize = () => {
+    if (isTerminalVisible && fitAddonRef.current && terminalRef.current) { // Added terminalRef.current check here
+      requestAnimationFrame(() => {
         try {
+          if (fitAddonRef.current && terminalRef.current && terminalRef.current.clientWidth > 0 && terminalRef.current.clientHeight > 0) {
             fitAddonRef.current.fit();
-        } catch(e) {
-            // console.warn("FitAddon fit error on window resize (visible):", e);
+          } else if (terminalRef.current) { // Log only if terminalRef exists but dimensions are zero
+            // console.warn("Terminal container has zero dimensions on resize. Skipping fit().",
+            //    `Width: ${terminalRef.current.clientWidth}, Height: ${terminalRef.current.clientHeight}`);
+          }
+        } catch (e) {
+          // console.warn("FitAddon fit error on window resize (rAF, dim check):", e);
+        }
+      });
+    }
+  };
+
+  useEffect(() => {
+    if (isTerminalVisible) {
+      if (terminalRef.current && !xtermRef.current) { // Only initialize if visible and not already initialized
+        const term = new Terminal({
+          cursorBlink: true,
+          convertEol: true,
+          theme: {
+            background: '#0F172A',
+            foreground: '#E2E8F0',
+            cursor: '#F87171',
+            selectionBackground: '#64748B',
+            selectionForeground: '#FFFFFF',
+            black: '#1E293B',
+            red: '#F87171',
+            green: '#4ADE80',
+            yellow: '#FACC15',
+            blue: '#60A5FA',
+            magenta: '#F472B6',
+            cyan: '#2DD4BF',
+            white: '#F1F5F9',
+            brightBlack: '#64748B',
+            brightRed: '#FB923C',
+            brightGreen: '#86EFAC',
+            brightYellow: '#FDE047',
+            brightBlue: '#93C5FD',
+            brightMagenta: '#F0ABFC',
+            brightCyan: '#67E8F9',
+            brightWhite: '#FFFFFF',
+          },
+          fontSize: 14,
+          fontFamily: 'Menlo, "DejaVu Sans Mono", Consolas, "Lucida Console", monospace',
+          rows: 25,
+          scrollback: 1000,
+        });
+
+        const fitAddon = new FitAddon();
+        fitAddonRef.current = fitAddon;
+        term.loadAddon(fitAddon);
+        
+        term.open(terminalRef.current);
+        xtermRef.current = term; // Store instance
+
+        requestAnimationFrame(() => {
+          try {
+            if (fitAddonRef.current && terminalRef.current && terminalRef.current.clientWidth > 0 && terminalRef.current.clientHeight > 0) {
+              fitAddonRef.current.fit();
+            } else if (terminalRef.current) {
+              // console.warn("Terminal container has zero dimensions on initial load. Skipping fit().",
+              //  `Width: ${terminalRef.current.clientWidth}, Height: ${terminalRef.current.clientHeight}`);
+            }
+          } catch (e) {
+            // console.warn("FitAddon fit error on initial load (rAF, dim check):", e);
+          }
+        });
+        term.focus();
+
+        term.onResize(({ cols, rows }) => {
+          if (onData) {
+            onData(JSON.stringify({ type: 'resize', cols, rows }));
+          }
+        });
+        // Send initial size
+        if (onData) {
+            onData(JSON.stringify({ type: 'resize', cols: term.cols, rows: term.rows }));
+        }
+
+        term.onData(data => {
+          if (onData && isConnected) {
+            onData(data);
+          } else if (!isConnected && xtermRef.current) {
+            xtermRef.current.writeln("\r\n[OFFLINE: Input not sent. Waiting for connection...]");
+          }
+        });
+
+        // Write any buffered initial output upon new terminal creation
+        if (initialOutput && initialOutput.length > lastOutputLength.current) {
+            xtermRef.current.write(initialOutput.substring(lastOutputLength.current));
+            lastOutputLength.current = initialOutput.length; // Update after writing
+            xtermRef.current.scrollToBottom();
+        } else if (initialOutput === '' && lastOutputLength.current > 0) {
+            xtermRef.current.clear();
+            lastOutputLength.current = 0;
         }
       }
-    };
-    window.addEventListener('resize', handleWindowResize);
-
-    // Effect to fit terminal when it becomes visible
-    if (isTerminalVisible && fitAddonRef.current && xtermRef.current) {
-        requestAnimationFrame(() => {
-            try {
-                if (fitAddonRef.current) {
-                     fitAddonRef.current.fit();
-                }
-            } catch (e) {
-                // console.warn("FitAddon fit error on tab visibility change (rAF):", e);
-            }
-        });
+      
+      // Add resize listener if visible and terminal exists
+      window.addEventListener('resize', handleWindowResize);
+    } else {
+      // Terminal is not visible, ensure it's disposed if it was previously visible
+      if (xtermRef.current) {
+        xtermRef.current.dispose();
+        xtermRef.current = null;
+        fitAddonRef.current = null; // Clear addon ref as well
+        lastOutputLength.current = 0; // Reset buffer tracking
+      }
+      // Remove resize listener if not visible
+      window.removeEventListener('resize', handleWindowResize);
     }
 
     return () => {
       window.removeEventListener('resize', handleWindowResize);
+      // Dispose on unmount if instance still exists (e.g. if unmounted while visible)
       if (xtermRef.current) {
         xtermRef.current.dispose();
         xtermRef.current = null;
-      }
-      fitAddonRef.current = null; 
-      lastOutputLength.current = 0; 
-    };
-  }, [onData, isConnected, isTerminalVisible]); // Added isTerminalVisible to dependency array
-
-  // Effect for writing dynamic initialOutput if component isn't remounted by key
-  // This mainly handles ongoing messages from WebSocket
-  useEffect(() => {
-    if (xtermRef.current && initialOutput && initialOutput.length > lastOutputLength.current) {
-        xtermRef.current.write(initialOutput.substring(lastOutputLength.current));
-        lastOutputLength.current = initialOutput.length;
-        xtermRef.current.scrollToBottom();
-    } else if (xtermRef.current && initialOutput === '' && lastOutputLength.current > 0) {
-        // This case handles if initialOutput is explicitly cleared by parent
-        xtermRef.current.clear();
+        fitAddonRef.current = null;
         lastOutputLength.current = 0;
+      }
+    };
+  }, [isTerminalVisible, onData, isConnected, initialOutput]); // initialOutput added to re-evaluate if terminal created late
+
+  // Effect for writing dynamic initialOutput if component is already visible and terminal exists
+  useEffect(() => {
+    if (isTerminalVisible && xtermRef.current) {
+      if (initialOutput && initialOutput.length > lastOutputLength.current) {
+          xtermRef.current.write(initialOutput.substring(lastOutputLength.current));
+          lastOutputLength.current = initialOutput.length;
+          xtermRef.current.scrollToBottom();
+      } else if (initialOutput === '' && lastOutputLength.current > 0) {
+          xtermRef.current.clear();
+          lastOutputLength.current = 0;
+      }
     }
-  }, [initialOutput]);
+  }, [initialOutput, isTerminalVisible]); // Re-run if initialOutput changes or visibility changes
 
 
   return (
@@ -184,7 +175,13 @@ const TerminalEmulator = ({
         </CardTitle>
       </CardHeader>
       <CardContent className="flex-grow p-0 overflow-hidden bg-slate-900">
-        <div ref={terminalRef} className="h-full w-full" />
+        {isTerminalVisible ? (
+          <div ref={terminalRef} className="h-full w-full" />
+        ) : (
+          <div className="p-4 text-slate-500 flex items-center justify-center h-full">
+            Terminal is hidden. Switch to this tab to activate.
+          </div>
+        )}
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
This commit implements more robust solutions to prevent the xterm.js "Cannot read properties of undefined (reading 'dimensions')" error.

Changes in src/components/lab/TerminalEmulator.jsx:

1.  **Conditional Rendering of XTerm:** The entire XTerm.js instance (creation, DOM element, event listeners) is now only rendered and initialized if the `isTerminalVisible` prop is true. When not visible, a placeholder is shown. This ensures xterm setup only occurs when its container is meant to be displayed.
2.  **Explicit Dimension Check:** Before `fitAddon.fit()` is called (even within `requestAnimationFrame` and when visible), there's an added check to ensure the terminal container `div` has clientWidth and clientHeight greater than zero. A warning is logged (commented out) if dimensions are zero, preventing `fit()` on an unmeasurable element.
3.  **Lifecycle Management:** Enhanced cleanup logic ensures that the xterm instance is disposed of and event listeners are removed when the terminal becomes hidden or the component unmounts.

These changes aim to definitively resolve the dimension calculation issues by ensuring xterm only operates on a visible and measurable container.